### PR TITLE
🐛 fix/GaugeComponent width 수정 및 props parameter 추가

### DIFF
--- a/src/components/GaugeComponent.tsx
+++ b/src/components/GaugeComponent.tsx
@@ -3,17 +3,17 @@ import { FaRunning } from "react-icons/fa";
 
 interface GaugeComponentProps {
     state : number;
-    color : string;
+    type : string;
 }
 
-function GaugeComponent ({state, color}:GaugeComponentProps) {
+function GaugeComponent ({state, type}:GaugeComponentProps) {
 
     return(
         <GaugeComponentWrap>
-            <Gauge $state={state} $color = {color}>
+            <Gauge $state={state} $type = {type}>
                 {state + '%'}
             </Gauge>
-            <FaRunning size={60} color={color}/>
+            <FaRunning size={60} color={type==="일급"?'B0FE5B':'1F4223'}/>
         </GaugeComponentWrap>
     )
 };
@@ -22,17 +22,18 @@ export default GaugeComponent;
 
 const GaugeComponentWrap = styled.div`
     display: flex;
-    width: 750px;
+    width: 810px;
     height: 60px;
 `;
 
-const Gauge = styled.div<{$state:number, $color:string}>`
+const Gauge = styled.div<{$state:number, $type:string}>`
     display: flex;
     justify-content: flex-end;
     align-items: center;
     width: ${(props)=>`${props.$state/100*720}`}px;
-    background-color: #${(props)=> `${props.$color}`};
+    background-color: #${(props)=> props.$type==='일급'?'B0FE5B':'1F4223'};
     padding-right: 20px;
     font-size: 32px;
-    font-family:'Press Start 2P';
+    font-family: 'Press Start 2P';
+    color: #${(props)=> props.$type==='일급'?'062D0A':'B0FE5B'};
 `;


### PR DESCRIPTION
🔀 What does this PR do? & Why are we doing this?


- [x] GaugeComponent의 100%가 100% 만큼의 width를 가지지 않는 현상 수정
- [x] GaugeComponent 요소의 색상을 효율적으로 바꾸기 위해 color로 받아오는 props를 type으로 변경

---

📸 Screenshots
- width 수정
![image](https://github.com/user-attachments/assets/26e8b1d9-fe56-4a85-959e-7aa6dfdabf2c)
![image](https://github.com/user-attachments/assets/9e87d394-7868-4c47-9448-0a4ba273ea1a)


- color 변경
![image](https://github.com/user-attachments/assets/a0c57f40-e370-439b-bd3d-bf6cc1c312f0)
![image](https://github.com/user-attachments/assets/9ac58e53-3368-4bce-a917-3e4ca733bff4)

---

📌 Related Issue
Closes #번호