### PR TITLE
🐛 fix/gaugeComponent의 width 작은 화면에서도 ui 깨지지 않도록 수정

### DIFF
--- a/src/components/GaugeComponent.tsx
+++ b/src/components/GaugeComponent.tsx
@@ -7,6 +7,7 @@ interface GaugeComponentProps {
 }
 
 function GaugeComponent({ state, type }: GaugeComponentProps) {
+  console.log(state);
   return (
     <GaugeComponentWrap>
       <Gauge $state={state} $type={type}>
@@ -21,7 +22,7 @@ export default GaugeComponent;
 
 const GaugeComponentWrap = styled.div`
   display: flex;
-  width: 810px;
+  width: 60%;
   height: 60px;
 `;
 
@@ -29,7 +30,7 @@ const Gauge = styled.div<{ $state: number; $type: string }>`
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  width: ${props => `${(props.$state / 100) * 720}`}px;
+  width: calc(${props => `${props.$state + 5}`}% - 60px);
   background-color: #${props => (props.$type === '일급' ? 'B0FE5B' : '1F4223')};
   padding-right: 20px;
   font-size: 32px;

--- a/src/components/GaugeComponent.tsx
+++ b/src/components/GaugeComponent.tsx
@@ -7,7 +7,6 @@ interface GaugeComponentProps {
 }
 
 function GaugeComponent({ state, type }: GaugeComponentProps) {
-  console.log(state);
   return (
     <GaugeComponentWrap>
       <Gauge $state={state} $type={type}>


### PR DESCRIPTION
🔀 What does this PR do? & Why are we doing this?

- [x] gaugeComponent의 width 작은 화면에서도 ui 깨지지 않도록 수정

---

📸 Screenshots

- 큰 화면
![image](https://github.com/user-attachments/assets/759e1fe4-6590-4c28-993c-6760df78db22)

- 작은 화면
![image](https://github.com/user-attachments/assets/c979c263-d89b-4e59-a5ff-92ac20176077)


---

📌 Related Issue
Closes #번호